### PR TITLE
fix(chart): set CPU usage chart y-axis maximum to 100%

### DIFF
--- a/src/components/CPU.vue
+++ b/src/components/CPU.vue
@@ -42,6 +42,12 @@ const options = ref({
   yAxis: {
     title: {
       text: null
+    },
+    max: 100, // Set maximum value to 100%
+    min: 0,   // Set minimum value to 0%
+    tickInterval: 25, // Create ticks at 0, 25, 50, 75, 100
+    labels: {
+      format: '{value}%' // Add % symbol to y-axis labels
     }
   },
   tooltip: {

--- a/src/components/CPU.vue
+++ b/src/components/CPU.vue
@@ -45,7 +45,6 @@ const options = ref({
     },
     max: 100, // Set maximum value to 100%
     min: 0,   // Set minimum value to 0%
-    tickInterval: 25, // Create ticks at 0, 25, 50, 75, 100
     labels: {
       format: '{value}%' // Add % symbol to y-axis labels
     }


### PR DESCRIPTION
主要修改:
此处上限应为100%
<img width="417" alt="image" src="https://github.com/user-attachments/assets/bff6c137-65c2-479e-b33c-2c0b6b4e7458" />


其他更改:
- 添加了y轴最小值设置为0%
- 设置刻度间隔为25，使刻度显示在0%、25%、50%、75%和100%
- 为y轴标签添加百分比符号格式